### PR TITLE
fix: allow inline styles and load JSZip in service worker

### DIFF
--- a/background.js
+++ b/background.js
@@ -35,9 +35,10 @@ async function createEPUBFile(data) {
 
 async function loadJSZip() {
     try {
-        // Загружаем JSZip из локального файла
-        await import('./jszip.min.js');
-        
+        // AICODE-TRAP: import() unsupported in service workers, use importScripts instead [2025-08-10]
+        // AICODE-WHY: Load JSZip locally to avoid network dependency during EPUB generation [2025-08-10]
+        importScripts('jszip.min.js');
+
         if (typeof JSZip === 'undefined') {
             throw new Error('JSZip не загружен из локального файла');
         }

--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,6 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; default-src 'self'"
+    "extension_pages": "script-src 'self'; object-src 'self'; style-src 'self' 'unsafe-inline'; default-src 'self'"
   }
 }


### PR DESCRIPTION
## Summary
- permit inline styling in extension pages by expanding CSP
- load JSZip via `importScripts` to satisfy ServiceWorker restrictions

## Testing
- `node --check background.js`
- `jq . manifest.json >/tmp/manifest.formatted.json && head -n 20 /tmp/manifest.formatted.json`


------
https://chatgpt.com/codex/tasks/task_e_689860dde4e8832ba6e7662da8fc84d5