### PR TITLE
Add basic tests for EPUBGenerator utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "epub-exporter",
+  "version": "1.0.0",
+  "description": "Полнофункциональное Chrome расширение для извлечения контента из веб-страниц и конвертации в формат EPUB, оптимизированный для PocketBook и других электронных читалок.",
+  "main": "background.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/test/epub_generator.test.js
+++ b/test/epub_generator.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const EPUBGenerator = require('../epub_generator');
+
+// AICODE-WHY: Validates EPUBGenerator utility methods to prevent regressions in EPUB creation logic [2025-08-10]
+
+test('sanitizeTitle removes invalid characters and trims', () => {
+  const gen = new EPUBGenerator();
+  assert.strictEqual(gen.sanitizeTitle(' Hello!/\\ '), 'Hello');
+});
+
+test('sanitizeTitle returns default for empty title', () => {
+  const gen = new EPUBGenerator();
+  assert.strictEqual(gen.sanitizeTitle(''), 'Экспортированная статья');
+});
+
+test('sanitizeContent returns default message when content empty', () => {
+  const gen = new EPUBGenerator();
+  assert.strictEqual(gen.sanitizeContent(''), '<p>Контент не найден.</p>');
+});
+
+test('processImages filters out entries without base64 or src', () => {
+  const gen = new EPUBGenerator();
+  const images = [
+    { base64: 'data:image/png;base64,AAA', src: 'a.png' },
+    { base64: null, src: 'b.png' },
+    { base64: 'data:image/png;base64,BBB', src: null }
+  ];
+  assert.deepStrictEqual(gen.processImages(images), [
+    { base64: 'data:image/png;base64,AAA', src: 'a.png' }
+  ]);
+});
+
+test('generateFilename creates epub with sanitized title and date', () => {
+  const gen = new EPUBGenerator();
+  const filename = gen.generateFilename('Title! with *chars*');
+  assert.match(filename, /^Title_with_chars_\d{4}-\d{2}-\d{2}\.epub$/);
+});
+
+test('getImageExtension detects format from base64 prefix', () => {
+  const gen = new EPUBGenerator();
+  assert.strictEqual(gen.getImageExtension('data:image/png;base64,'), 'png');
+  assert.strictEqual(gen.getImageExtension('data:image/webp;base64,'), 'webp');
+  assert.strictEqual(gen.getImageExtension('data:image/unknown;base64,'), 'jpg');
+});
+
+test('escapeXML escapes special characters', () => {
+  const gen = new EPUBGenerator();
+  const input = '<tag attr="value">&\'';
+  const expected = '&lt;tag attr=&quot;value&quot;&gt;&amp;&apos;';
+  assert.strictEqual(gen.escapeXML(input), expected);
+});


### PR DESCRIPTION
## Summary
- add package.json with node test script
- cover EPUBGenerator utility functions with minimal node:test suite

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68986636b800832bb36e4270283d77a6