### PR TITLE
fix: inject content script when message connection fails

### DIFF
--- a/extractContent.js
+++ b/extractContent.js
@@ -1,0 +1,24 @@
+// AICODE-TRAP: tabs.sendMessage fails if content script isn't injected [2025-08-10]
+// AICODE-WHY: Inject content script on demand to handle pages without automatic injection [2025-08-10]
+async function extractContentFromTab(tabId) {
+  try {
+    return await chrome.tabs.sendMessage(tabId, { action: 'extractContent' });
+  } catch (err) {
+    if (err.message && err.message.includes('Could not establish connection')) {
+      await chrome.scripting.executeScript({
+        target: { tabId },
+        files: ['content_script.js']
+      });
+      return await chrome.tabs.sendMessage(tabId, { action: 'extractContent' });
+    }
+    throw err;
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.extractContentFromTab = extractContentFromTab;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { extractContentFromTab };
+}

--- a/extractContent.test.js
+++ b/extractContent.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { extractContentFromTab } = require('./extractContent');
+
+test('injects content script when missing', async (t) => {
+  let call = 0;
+  const sendMessage = t.mock.fn(async () => {
+    if (call++ === 0) {
+      throw new Error('Could not establish connection. Receiving end does not exist.');
+    }
+    return { success: true };
+  });
+  const executeScript = t.mock.fn(async () => {});
+  global.chrome = { tabs: { sendMessage }, scripting: { executeScript } };
+
+  const result = await extractContentFromTab(123);
+  assert.deepEqual(result, { success: true });
+  assert.equal(sendMessage.mock.callCount(), 2);
+  assert.deepEqual(executeScript.mock.calls[0].arguments[0], { target: { tabId: 123 }, files: ['content_script.js'] });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,8 @@
   "description": "Экспорт контента веб-страниц в формат EPUB для PocketBook",
   "permissions": [
     "activeTab",
-    "downloads"
+    "downloads",
+    "scripting"
   ],
   "action": {
     "default_popup": "popup.html",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "epub-exporter",
+  "version": "1.0.0",
+  "description": "Полнофункциональное Chrome расширение для извлечения контента из веб-страниц и конвертации в формат EPUB, оптимизированный для PocketBook и других электронных читалок.",
+  "main": "background.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/popup.html
+++ b/popup.html
@@ -104,6 +104,7 @@
         </div>
         <div id="status" class="status"></div>
     </div>
+    <script src="extractContent.js"></script>
     <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -16,7 +16,8 @@ document.addEventListener('DOMContentLoaded', function() {
             setProgress(30);
             
             // Отправляем сообщение в content script
-            const response = await chrome.tabs.sendMessage(tab.id, { action: 'extractContent' });
+            // AICODE-LINK: ./extractContent.js#extractContentFromTab
+            const response = await extractContentFromTab(tab.id);
             
             if (!response || !response.success) {
                 throw new Error(response?.error || 'Не удалось извлечь контент');


### PR DESCRIPTION
## Summary
- add extraction helper that injects content script when sendMessage has no receiver
- call helper from popup and expose in HTML
- grant scripting permission and cover with node test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689866c43c40832b849cfed88d42afa0