### PR TITLE
Fix JSZip loading without dynamic import

### DIFF
--- a/background.js
+++ b/background.js
@@ -33,14 +33,16 @@ async function createEPUBFile(data) {
     }
 }
 
+// AICODE-LINK: ./epub_generator.js#loadJSZip
 async function loadJSZip() {
     try {
-        // AICODE-TRAP: importScripts throws DOMException in MV3 service workers; prefer dynamic import with chrome.runtime.getURL [2025-08-10]
+        // AICODE-TRAP: import() disallowed in ServiceWorkerGlobalScope; load via fetch + Function [2025-08-11]
         // AICODE-WHY: Load JSZip locally to avoid network dependency during EPUB generation [2025-08-10]
         const jszipUrl = chrome.runtime.getURL('jszip.min.js');
-        await import(jszipUrl);
+        const response = await fetch(jszipUrl);
+        const scriptText = await response.text();
+        const JSZip = new Function(`${scriptText}; return JSZip;`)();
 
-        const JSZip = self.JSZip;
         if (typeof JSZip === 'undefined') {
             throw new Error('JSZip не загружен из локального файла');
         }

--- a/test/epub_generator.test.js
+++ b/test/epub_generator.test.js
@@ -50,3 +50,10 @@ test('escapeXML escapes special characters', () => {
   const expected = '&lt;tag attr=&quot;value&quot;&gt;&amp;&apos;';
   assert.strictEqual(gen.escapeXML(input), expected);
 });
+
+test('loadJSZip loads JSZip library from local file', async () => {
+  const gen = new EPUBGenerator();
+  const JSZip = await gen.loadJSZip();
+  assert.equal(typeof JSZip.prototype.file, 'function');
+  assert.equal(typeof JSZip.prototype.generateAsync, 'function');
+});


### PR DESCRIPTION
## Summary
- add failing test for JSZip loader
- load JSZip via fetch and evaluation to avoid dynamic import restrictions in service worker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898d6ba3d54832bb3b8560d89b40033