### PR TITLE
feat: add jsdoc typing and tsconfig

### DIFF
--- a/extractContent.js
+++ b/extractContent.js
@@ -1,22 +1,50 @@
+// @ts-check
+/* global chrome, module, window */
 // AICODE-TRAP: tabs.sendMessage fails if content script isn't injected [2025-08-10]
 // AICODE-WHY: Inject content script on demand to handle pages without automatic injection [2025-08-10]
+// AICODE-LINK: ./content_script.js#extractPageContent
+
+/**
+ * @typedef {Object} ExtractedImage
+ * @property {string} src
+ * @property {string} base64
+ * @property {string} alt
+ * @property {number|string} width
+ * @property {number|string} height
+ */
+
+/**
+ * @typedef {Object} ExtractedContent
+ * @property {string} title
+ * @property {string} content
+ * @property {ExtractedImage[]} images
+ * @property {string} url
+ * @property {string} timestamp
+ */
+
+/**
+ * Отправляет запрос на извлечение контента из вкладки.
+ * @param {number} tabId
+ * @returns {Promise<{success: boolean, data?: ExtractedContent, error?: string}>}
+ */
 async function extractContentFromTab(tabId) {
   try {
     return await chrome.tabs.sendMessage(tabId, { action: 'extractContent' });
   } catch (err) {
-    if (err.message && err.message.includes('Could not establish connection')) {
+    const error = /** @type {Error} */ (err);
+    if (error.message && error.message.includes('Could not establish connection')) {
       await chrome.scripting.executeScript({
         target: { tabId },
         files: ['content_script.js']
       });
       return await chrome.tabs.sendMessage(tabId, { action: 'extractContent' });
     }
-    throw err;
+    throw error;
   }
 }
 
 if (typeof window !== 'undefined') {
-  window.extractContentFromTab = extractContentFromTab;
+  /** @type {any} */ (window).extractContentFromTab = extractContentFromTab;
 }
 
 if (typeof module !== 'undefined') {

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,5 @@
+/* AICODE-WHY: Minimal global declarations to satisfy TypeScript when npm types unavailable [2025-08-13] */
+declare const chrome: any;
+declare const JSZip: any;
+declare const module: any;
+declare function extractContentFromTab(tabId: number): Promise<any>;

--- a/jszip.min.js
+++ b/jszip.min.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /*!
 
 JSZip v3.10.1 - A JavaScript class for generating and reading zip files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "epub-exporter",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "epub-exporter",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Полнофункциональное Chrome расширение для извлечения контента из веб-страниц и конвертации в формат EPUB, оптимизированный для PocketBook и других электронных читалок.",
   "main": "background.js",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  // AICODE-WHY: Enable TypeScript checking for JavaScript with JSDoc to improve reliability without a full TS migration [2025-08-13]
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "strict": true,
+    "noImplicitAny": false,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.js", "**/*.d.ts"],
+  "exclude": ["node_modules", "jszip.min.js", "memory-bank", "test/**", "**/*.test.js"]
+}


### PR DESCRIPTION
## Summary
- add JSDoc typedefs across extension scripts and popup UI
- introduce tsconfig for project-wide type checking
- stub global chrome and JSZip types for TypeScript

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6898f4b3913c832bbad1eeec97e915c2