### PR TITLE
fix: add Dropbox connectivity check

### DIFF
--- a/dropbox_client.js
+++ b/dropbox_client.js
@@ -64,10 +64,28 @@ class DropboxClient {
      * @returns {boolean}
      */
     isConfigured() {
-        return !!(DROPBOX_CONFIG.APP_KEY && 
-                  DROPBOX_CONFIG.APP_SECRET && 
+        return !!(DROPBOX_CONFIG.APP_KEY &&
+                  DROPBOX_CONFIG.APP_SECRET &&
                   DROPBOX_CONFIG.REFRESH_TOKEN &&
                   DROPBOX_CONFIG.APP_KEY !== 'your_dropbox_app_key_here');
+    }
+
+    /**
+     * Проверяет подключение к Dropbox и валидность конфигурации
+     * @returns {Promise<boolean>}
+     */
+    async isConnected() {
+        if (!this.isConfigured()) {
+            return false;
+        }
+        try {
+            await this.getUserInfo();
+            return true;
+        } catch (error) {
+            // AICODE-TRAP: Ошибки сети или токена считаем отсутствием подключения [2025-02-14]
+            console.error('Dropbox connection check failed:', error);
+            return false;
+        }
     }
 
     /**

--- a/test/dropbox_client.test.mjs
+++ b/test/dropbox_client.test.mjs
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Provide global config before importing client
+const DROPBOX_CONFIG = {
+    APP_KEY: 'your_dropbox_app_key_here',
+    APP_SECRET: 'your_dropbox_app_secret_here',
+    REFRESH_TOKEN: 'your_dropbox_refresh_token_here',
+    TARGET_FOLDER: '/Apps/EPUB Exporter'
+};
+
+// Set global variable expected by dropbox_client.js
+globalThis.DROPBOX_CONFIG = DROPBOX_CONFIG;
+
+// Dynamic import after setting globals
+const { default: DropboxClient } = await import('../dropbox_client.js');
+
+test('isConnected should exist and return boolean', async (t) => {
+    const client = new DropboxClient();
+    assert.equal(typeof client.isConnected, 'function');
+    const connected = await client.isConnected();
+    assert.equal(connected, false);
+});


### PR DESCRIPTION
## Summary
- add `isConnected` method to Dropbox client to verify configuration and user access
- cover Dropbox connectivity logic with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a34d644074832b803ccd78182eb3cd